### PR TITLE
Numeração errada

### DIFF
--- a/app/design/frontend/base/default/template/onestepcheckout/onestep.phtml
+++ b/app/design/frontend/base/default/template/onestepcheckout/onestep.phtml
@@ -33,8 +33,8 @@
         <div class="col-3">
             <div class="opc">
                 <div class="section allow active">
-                    <?php $blockNumberClass = (!is_null($this->getBlockNumber(false))) ? "onestepcheckout-number-v" : ""; ?>
-                    <?php if(Mage::getStoreConfig('onestepcheckout/general/is_show_titles')): ?><div class="step-title"><span class="number onestepcheckout-number <?php echo $blockNumberClass; ?>">v</span><h2><?php echo $this->__('ORDER REVIEW'); ?></h2></div><?php endif; ?>
+                    <?php $blockNumberClass = (!is_null($this->getBlockNumber(false))) ? "onestepcheckout-number-4" : ""; ?>
+                    <?php if(Mage::getStoreConfig('onestepcheckout/general/is_show_titles')): ?><div class="step-title"><span class="number onestepcheckout-number <?php echo $blockNumberClass; ?>">4</span><h2><?php echo $this->__('ORDER REVIEW'); ?></h2></div><?php endif; ?>
                     <div class="step a-item">
                         <div id="onestepcheckout-order-review">
                             <div id="onestepcheckout-order-review-cart-wrapper">


### PR DESCRIPTION
Os passos no checkout agora estão corretos do 1 ao 4, estava o "v" no lugar do 4° passo.
