### PR TITLE
Tradução dummy message

### DIFF
--- a/app/design/frontend/base/default/template/onestepcheckout/customer/form/edit.phtml
+++ b/app/design/frontend/base/default/template/onestepcheckout/customer/form/edit.phtml
@@ -45,7 +45,7 @@
             <li>
                 <label for="current_password" class="required"><em>*</em><?php echo $this->__('Current Password') ?></label>
                 <div class="input-box">
-                    <!-- This is a dummy hidden field to trick firefox from auto filling the password -->
+                    <!-- Este é um campo fictício escondido para enganar o Firefox no auto preenchimento de senha -->
                     <input type="text" class="input-text no-display" name="dummy" id="dummy" />
                     <input type="password" title="<?php echo $this->__('Current Password') ?>" class="input-text" name="current_password" id="current_password" />
                 </div>


### PR DESCRIPTION
Ajuda desenvolvedores que não sabem inglês ter uma rápida interpretação do escopo geral do código, além de seguir o padrão das funções e métodos em português do módulo.