### PR TITLE
Tornando IE/RG obrigatório

### DIFF
--- a/app/design/frontend/base/default/template/onestepcheckout/customer/widget/ie.phtml
+++ b/app/design/frontend/base/default/template/onestepcheckout/customer/widget/ie.phtml
@@ -7,7 +7,7 @@
  */
 ?>
 
-<label for="<?php echo $this->getFieldId('ie')?>"<?php if ($this->isRequired()) echo ' class="required"' ?>><?php if ($this->isRequired()) echo '<em>*</em>' ?><?php echo $this->__('IE (Inscrição Estadual)') ?></label>
+<label for="<?php echo $this->getFieldId('ie')?>" class="required"><em>*</em><?php echo $this->__('Label IE/RG. Se você está lendo esta mensagem, provavelmente tem um erro de configuração ou JS.') ?></label>
 <div class="input-box">
-    <input type="text" id="<?php echo $this->getFieldId('ie')?>" name="<?php echo $this->getFieldName('ie')?>" title="<?php echo $this->__('IE (Inscrição Estadual)') ?>" class="input-text" value="<?php echo $this->getCustomer()->getIe(); ?>" />
+    <input type="text" id="<?php echo $this->getFieldId('ie')?>" name="<?php echo $this->getFieldName('ie')?>" title="<?php echo $this->__('IE (Inscrição Estadual)') ?>" class="input-text required-entry" value="<?php echo $this->getCustomer()->getIe(); ?>" />
 </div>


### PR DESCRIPTION
Fiz uma instalação numa loja limpa e o campo RG/IE não vinha como obrigatório, mas aparecia o asterisco(sem estilo CSS) ao lado do nome.
Investigando, vi que a função JS ```setTipopessoaArea``` sempre coloca o código ```<em>*</em>``` no label do campo RG/IE.

Imaginei que este campo deve ser sempre obrigatório uma vez que:
- Não existe configuração no admin para tornar obrigatório ou não este campo;
- Sempre é adicionado ```<em>*</em>``` via JS ao label.

Removi o teste PHP se o campo é requerido, assim ele sempre será requerido.
Troquei o label padrão para ```Label IE/RG. Se você está lendo esta mensagem, provavelmente tem um erro de configuração ou JS.```, assim quando alguém for instalar o módulo e der algum problema de JS, ajudará a pessoa. Se tudo funcionar corretamente, este label será substituido via JS pelo label correto.