### PR TITLE
Posicionamento do seletor pessoa física e jurídica.

### DIFF
--- a/app/design/frontend/base/default/template/onestepcheckout/onestep/form/address/billing.phtml
+++ b/app/design/frontend/base/default/template/onestepcheckout/onestep/form/address/billing.phtml
@@ -24,7 +24,8 @@
                     <?php if ($_tipopessoa->isEnabled()): ?>
                         <li class="control tipopessoa">
                             <input type="radio" name="billing[radio_tipopessoa]" value="Física" id="billing:fisica" class="radio" title="CPF" <?php if ($this->getDataFromSession('radio_tipopessoa') == 'Física'): ?> checked="checked"<?php endif; ?>/><label for="billing:fisica"><?php echo $this->__('Pessoa Física') ?></label>
-                            <input type="radio" name="billing[radio_tipopessoa]" value="Jurídica" id="billing:juridica" class="radio" title="CNPJ" <?php if ($this->getDataFromSession('radio_tipopessoa') == 'Jurídica'): ?> checked="checked"<?php endif; ?>/><label for="billing:juridica"><?php echo $this->__('Pessoa Jurídica') ?></label>
+                            <br></br>
+							<input type="radio" name="billing[radio_tipopessoa]" value="Jurídica" id="billing:juridica" class="radio" title="CNPJ" <?php if ($this->getDataFromSession('radio_tipopessoa') == 'Jurídica'): ?> checked="checked"<?php endif; ?>/><label for="billing:juridica"><?php echo $this->__('Pessoa Jurídica') ?></label>
                         </li>
                         <li class="wide hidden">
                             <?php echo $_tipopessoa->setTipopessoa($this->getDataFromSession('tipopessoa'))->setFieldIdFormat('billing:%s')->setFieldNameFormat('billing[%s]')->toHtml() ?>


### PR DESCRIPTION
Olá, no meu site a seleção de pessoa física e jurídica estava confusa.
Estava escrito:
Pessoa Física Pessoa Jurídica Radio1 Radio2

Onde Radio1 e 2 são os botões para o cliente selecionar, estava tudo um de atrás do outro.

Resolvi o problema adicionando um < br > < / br > (sem os espaços) na linha 26 do arquivo frontend/base/default/template/onestepcheckout/onestep/form/address/billing.phtml

Gostaria de propor esta melhoria.