### PR TITLE
Suporte para instalação com composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "name": "inovarti/osc-magento-brasil-6",
+    "type": "magento-module",
+    "description":"Magento Extension for Magento Checkout",
+}

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
     "name": "inovarti/osc-magento-brasil-6",
     "type": "magento-module",
-    "description":"Magento Extension for Magento Checkout",
+    "description":"Magento Extension for Magento Checkout"
 }

--- a/modman
+++ b/modman
@@ -72,7 +72,6 @@ app/design/frontend/rwd/default/template/onestepcheckout/persistent/customer/for
 app/etc/modules/Inovarti_Onestepcheckout.xml app/etc/modules/Inovarti_Onestepcheckout.xml
 app/locale/en_US/Inovarti_Onestepcheckout.csv app/locale/en_US/Inovarti_Onestepcheckout.csv
 app/locale/pt_BR/Inovarti_Onestepcheckout.csv app/locale/pt_BR/Inovarti_Onestepcheckout.csv
-README.md README.md
 skin/frontend/base/default/onestepcheckout/css/onestepcheckout.css skin/frontend/base/default/onestepcheckout/css/onestepcheckout.css
 skin/frontend/base/default/onestepcheckout/images/ajax-loader-16px.gif skin/frontend/base/default/onestepcheckout/images/ajax-loader-16px.gif
 skin/frontend/base/default/onestepcheckout/images/ajax-loader-24px.gif skin/frontend/base/default/onestepcheckout/images/ajax-loader-24px.gif


### PR DESCRIPTION
É possível instalar módulos usando o composer.

Ver https://github.com/Cotya/magento-composer-installer

nesse link explica como adicionar o repositorio pessoal, para isso é necessário o composer.json https://github.com/Cotya/magento-composer-installer/blob/3.0/doc/MakeAModuleInstallableWithComposer.md
