### PR TITLE
adicionado timeout de conexão de socket para evitar travamento

### DIFF
--- a/app/code/community/Inovarti/Onestepcheckout/controllers/AjaxController.php
+++ b/app/code/community/Inovarti/Onestepcheckout/controllers/AjaxController.php
@@ -748,7 +748,7 @@ class Inovarti_Onestepcheckout_AjaxController extends Mage_Checkout_Controller_A
         $return = '';
 
         try {
-
+            ini_set('default_socket_timeout', 5);
             $clientSoap = new SoapClient("https://apps.correios.com.br/SigepMasterJPA/AtendeClienteService/AtendeCliente?wsdl", array(
                 'soap_version' => SOAP_1_1, 'encoding' => 'utf-8', 'trace' => true, 'exceptions' => true,
                 'cache_wsdl' => WSDL_CACHE_BOTH, 'connection_timeout' => 5

--- a/app/code/community/Inovarti/Onestepcheckout/controllers/AjaxController.php
+++ b/app/code/community/Inovarti/Onestepcheckout/controllers/AjaxController.php
@@ -739,32 +739,15 @@ class Inovarti_Onestepcheckout_AjaxController extends Mage_Checkout_Controller_A
         }
 
         $cep = preg_replace('/[^\d]/', '', $cep);
-
-        $soapArgs = array(
-            'cep' => $cep,
-            'encoding' => 'UTF-8',
-            'exceptions' => 0
-        );
         $return = '';
 
         try {
-            ini_set('default_socket_timeout', 5);
-            $clientSoap = new SoapClient("https://apps.correios.com.br/SigepMasterJPA/AtendeClienteService/AtendeCliente?wsdl", array(
-                'soap_version' => SOAP_1_1, 'encoding' => 'utf-8', 'trace' => true, 'exceptions' => true,
-                'cache_wsdl' => WSDL_CACHE_BOTH, 'connection_timeout' => 5
-            ));
-
-            $result = $clientSoap->consultaCep($soapArgs);
-            $dados = $result->return;
-
-            if (is_soap_fault($result)) {
-                $return = "var resultadoCEP = { 'uf' : '', 'cidade' : '', 'bairro' : '', 'tipo_logradouro' : '', 'logradouro' : '', 'resultado' : '0', 'resultado_txt' : 'cep nao encontrado' }";
-            }else{
-                $return = "var resultadoCEP = { 'uf' : '".$dados->uf."', 'cidade' : '".$dados->cidade."', 'bairro' : '".$dados->bairro."', 'tipo_logradouro' : '', 'logradouro' : '".$dados->end."', 'resultado' : '1', 'resultado_txt' : 'sucesso%20-%20cep%20completo' }";
+            $result = @file_get_contents('http://api.postmon.com.br/v1/cep/'.$cep);
+            if (! $result) {
+                throw new Exception('Cep não encontrado');
             }
-
-        } catch (SoapFault $e) {
-            $return = "var resultadoCEP = { 'uf' : '', 'cidade' : '', 'bairro' : '', 'tipo_logradouro' : '', 'logradouro' : '', 'resultado' : '0', 'resultado_txt' : 'cep nao encontrado' }";
+            $dados = json_decode($result);
+            $return = "var resultadoCEP = { 'uf' : '".$dados->estado."', 'cidade' : '".$dados->cidade."', 'bairro' : '".$dados->bairro."', 'tipo_logradouro' : '', 'logradouro' : '".$dados->logradouro."', 'resultado' : '1', 'resultado_txt' : 'sucesso%20-%20cep%20completo' }";
         } catch (Exception $e) {
             $return = "var resultadoCEP = { 'uf' : '', 'cidade' : '', 'bairro' : '', 'tipo_logradouro' : '', 'logradouro' : '', 'resultado' : '0', 'resultado_txt' : 'cep nao encontrado' }";
         }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "name": "inovarti/osc-magento-brasil-6",
+    "type": "magento-module",
+    "description":"Magento Extension for Magento Checkout"
+}

--- a/modman
+++ b/modman
@@ -72,7 +72,6 @@ app/design/frontend/rwd/default/template/onestepcheckout/persistent/customer/for
 app/etc/modules/Inovarti_Onestepcheckout.xml app/etc/modules/Inovarti_Onestepcheckout.xml
 app/locale/en_US/Inovarti_Onestepcheckout.csv app/locale/en_US/Inovarti_Onestepcheckout.csv
 app/locale/pt_BR/Inovarti_Onestepcheckout.csv app/locale/pt_BR/Inovarti_Onestepcheckout.csv
-README.md README.md
 skin/frontend/base/default/onestepcheckout/css/onestepcheckout.css skin/frontend/base/default/onestepcheckout/css/onestepcheckout.css
 skin/frontend/base/default/onestepcheckout/images/ajax-loader-16px.gif skin/frontend/base/default/onestepcheckout/images/ajax-loader-16px.gif
 skin/frontend/base/default/onestepcheckout/images/ajax-loader-24px.gif skin/frontend/base/default/onestepcheckout/images/ajax-loader-24px.gif


### PR DESCRIPTION
De acordo com o manual do php, o parametro "connection_timeout" passado na biblioteca SoapClient, não é suficiente para definir timeout dos serviços. para isso deve-se definir na variável "default_socket_timeout"
